### PR TITLE
fix: skip empty stream groups in playlist formatter

### DIFF
--- a/scripts/commands/playlist/format.ts
+++ b/scripts/commands/playlist/format.ts
@@ -58,7 +58,7 @@ async function main() {
   for (let filepath of groupedStreams.keys()) {
     const streams = groupedStreams.get(filepath) || []
 
-    if (!streams.length) return
+    if (!streams.length) continue
 
     const playlist = new Playlist(streams, { public: false })
     await storage.save(filepath, playlist.toString())


### PR DESCRIPTION
## Summary
- avoid exiting the playlist formatter when a group has no streams

## Testing
- `npm test` (fails: `jest` not found)
- `npm install jest --no-save` (fails: 403 Forbidden from registry)


------
https://chatgpt.com/codex/tasks/task_e_6893b3a5a600832b901a06d873ee66b5